### PR TITLE
Test against ember data release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "10"
 
 before_install:
-  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
-  - npm config set spin false
+  - if [[ `npm -v` != 6* ]]; then npm i -g npm@6; fi
   - npm install -g bower
   - bower --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
   - "10"
 
 before_install:
-  - if [[ `npm -v` != 6* ]]; then npm i -g npm@6; fi
+
+  # TODO: remove when we stop testing against node 6
+  - if [[ `npm -v` < 6* ]]; then npm i -g npm@6; fi
+
   - npm install -g bower
   - bower --version

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,7 @@ function installPristineApp(appName, options) {
     hasBowerComponents,
     skipNpm,
     emberVersion: options.emberVersion || 'canary',
-    emberDataVersion: options.emberDataVersion || '^3.6.0'
+    emberDataVersion: options.emberDataVersion || '^3.8.0'
   };
 
   promise = promise

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,7 @@ function installPristineApp(appName, options) {
     hasBowerComponents,
     skipNpm,
     emberVersion: options.emberVersion || 'canary',
-    emberDataVersion: options.emberDataVersion || 'emberjs/data#v3.8.0'
+    emberDataVersion: options.emberDataVersion || '^3.6.0'
   };
 
   promise = promise

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,7 @@ function installPristineApp(appName, options) {
     hasBowerComponents,
     skipNpm,
     emberVersion: options.emberVersion || 'canary',
-    emberDataVersion: options.emberDataVersion || 'emberjs/data#master'
+    emberDataVersion: options.emberDataVersion || 'emberjs/data#v3.8.0'
   };
 
   promise = promise

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "chai": "^4.0.2",
     "cross-env": "^5.0.0",
-    "ember-cli": "~2.17.1",
+    "ember-cli": "~3.8.0",
     "ember-cli-fastboot": "^1.0.0",
     "eslint-config-sane": "^0.6.0",
     "eslint-plugin-prefer-let": "^1.0.1",


### PR DESCRIPTION
tomdale/ember-cli-addon-tests#208

ember-data#master has a hard dependency on ember-fetch and ember-cli-fastboot only looks in the hosts app addon for fastboot dependencies. ember-fetch is a second level deep and is not added to the fastboot package.json.

I think the best fix is to have ember-cli-fastboot recursively search each addon for fastboot dependencies. My attempts to fix the root course has fall flat thus far. #675